### PR TITLE
Fixes data load from outside gem dir

### DIFF
--- a/insult_generator.gemspec
+++ b/insult_generator.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "insult_generator"
-  s.version     = '0.0.1'
+  s.version     = '0.0.2'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Arvind Kunday"]
   s.email       = ["hi@kunday.com"]

--- a/lib/insult_generator.rb
+++ b/lib/insult_generator.rb
@@ -2,7 +2,8 @@ require 'yaml'
 
 class InsultGenerator
   def self.random_insult
-    data = YAML.load_file(File.expand_path("lib/data/insults.yml"))
+    data_file = File.join(File.dirname(__FILE__), "data/insults.yml")
+    data = YAML.load_file(data_file)
     column1_rand = data["column1"][rand(50)]
     column2_rand = data["column2"][rand(50)]
     column3_rand = data["column3"][rand(50)]


### PR DESCRIPTION
This PR fixes the error thrown when running the `generate_insult` bin:

```
Traceback (most recent call last):
	9: from /home/travishooper/.rbenv/versions/2.6.6/bin/generate_insult:23:in `<main>'
	8: from /home/travishooper/.rbenv/versions/2.6.6/bin/generate_insult:23:in `load'
	7: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/insult_generator-0.0.1/bin/generate_insult:3:in `<top (required)>'
	6: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	5: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	4: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/insult_generator-0.0.1/lib/insult_generator.rb:14:in `<top (required)>'
	3: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/insult_generator-0.0.1/lib/insult_generator.rb:5:in `random_insult'
	2: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/2.6.0/psych.rb:577:in `load_file'
	1: from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/2.6.0/psych.rb:577:in `open'
/home/travishooper/.rbenv/versions/2.6.6/lib/ruby/2.6.0/psych.rb:577:in `initialize': No such file or directory @ rb_sysopen - /home/travishooper/lib/data/insults.yml (Errno::ENOENT)
```